### PR TITLE
feature/layout-callback-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Changes on the `develop` branch, but not yet released, will be listed here.
 
 ### Features
 
--   Added `options` to `willShowItem` callback on `LayoutSource`, which now also contains a `previous` item snapshot. This allows making more informed changes to item contents based on the item update.
--   Added `layoutSource` to `shouldRenderItem` callback on `LayoutSource` to allow referencing the current layout source's state.
+-   [[#24](https://github.com/diatche/evergrid/pull/24)] Added `options` to `willShowItem` callback on `LayoutSource`, which now also contains a `previous` item snapshot. This allows making more informed changes to item contents based on the item update.
+-   [[#24](https://github.com/diatche/evergrid/pull/24)] Added `layoutSource` to `shouldRenderItem` callback on `LayoutSource` to allow referencing the current layout source's state.
 
 ## 0.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+## develop
+
+Changes on the `develop` branch, but not yet released, will be listed here.
+
+### Features
+
+-   Added `options` to `willShowItem` callback on `LayoutSource`, which now also contains a `previous` item snapshot. This allows making more informed changes to item contents based on the item update.
+
+## 0.0.1
+
+**19 Apr 2020**
+
+-   Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes on the `develop` branch, but not yet released, will be listed here.
 ### Features
 
 -   Added `options` to `willShowItem` callback on `LayoutSource`, which now also contains a `previous` item snapshot. This allows making more informed changes to item contents based on the item update.
+-   Added `layoutSource` to `shouldRenderItem` callback on `LayoutSource` to allow referencing the current layout source's state.
 
 ## 0.0.1
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ A cross-platform infinite 2D scrollable view with efficient cell recycling using
 
 For an overview see the [demo](https://github.com/diatche/evergrid-expo-demo).
 
+_Note that this package is in early stages of development and there may be breaking changes within semantically compatible versions. See [change log](CHANGELOG.md)._
+
 Documentation coming soon.
 
 ### Usage

--- a/src/LayoutSource.ts
+++ b/src/LayoutSource.ts
@@ -76,9 +76,10 @@ export interface IItemUpdateManyOptions extends IAnimationBaseOptions {
     forceRender?: boolean;
 }
 
-export interface IItemUpdateSingleOptions extends IAnimationBaseOptions {
+export interface IItemUpdateSingleOptions<T> extends IAnimationBaseOptions {
     created?: boolean;
     dequeued?: boolean;
+    previous?: IItemSnapshot<T>;
 }
 
 export interface IItemRenderOptions {
@@ -218,7 +219,7 @@ export interface LayoutSourceProps<T> {
      * Called before an item is displayed after
      * an update or creation.
      */
-    willShowItem?: (item: IItem<T>) => void;
+    willShowItem?: (item: IItem<T>, options: IItemUpdateSingleOptions<T>) => void;
 
     /**
      * Called before an item is hidden after
@@ -1043,8 +1044,12 @@ export default abstract class LayoutSource<
     updateItem(
         item: IItem<T>,
         index: T,
-        options?: IItemUpdateSingleOptions,
+        options?: IItemUpdateSingleOptions<T>,
     ): Animated.CompositeAnimation | undefined {
+        const itemSnapshot: IItemSnapshot<T> = {
+            index: item.index,
+            contentLayout: item.contentLayout,
+        }
         let previousContentLayout = item.contentLayout;
         let newContentLayout = this.getItemContentLayout(index);
         // if (newContentLayout.size.x <= 0 || newContentLayout.size.y <= 0) {
@@ -1135,7 +1140,10 @@ export default abstract class LayoutSource<
             item.animated.opacity.setValue(1);
         }
 
-        this.props.willShowItem?.(item);
+        this.props.willShowItem?.(item, {
+            ...options,
+            previous: itemSnapshot,
+        });
         this.setVisibleItem(index, item);
 
         if (animations.length !== 0) {

--- a/src/LayoutSource.ts
+++ b/src/LayoutSource.ts
@@ -181,6 +181,7 @@ export interface LayoutSourceProps<T> {
     shouldRenderItem: (
         item: IItem<T>,
         previous: IItemSnapshot<T>,
+        layoutSource: LayoutSource,
     ) => boolean;
 
     /**
@@ -1349,7 +1350,7 @@ export default abstract class LayoutSource<
         if (!itemNode) {
             return;
         }
-        if (options?.force || this.props.shouldRenderItem(item, previous)) {
+        if (options?.force || this.props.shouldRenderItem(item, previous, this)) {
             // Update existing rendered node
             itemNode.setNeedsRender();
         }


### PR DESCRIPTION
-   Added `options` to `willShowItem` callback on `LayoutSource`, which now also contains a `previous` item snapshot. This allows making more informed changes to item contents based on the item update.
-   Added `layoutSource` to `shouldRenderItem` callback on `LayoutSource` to allow referencing the current layout source's state.