### PR TITLE
Scroll target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 Changes on the `master` branch, but not yet released, will be listed here.
 
+### Features
+
+-   It is now possible to call `scrollTo` and `scrollBy` multiple times. Scrolling information will be merged.
+-   Added previous and new values to `didChangeLocationOffsetBase` (previously `didChangeLocation`) and `willChangeScale` callbacks.
+-   Added `willChangeLocationOffsetBase` and `willChangeScale` callbacks, which fire before scrolling starts.
+
+### Breaking Changes
+
+-   Renamed `didChangeLocation` to `didChangeLocationOffsetBase`.
+
 ## 0.1.0
 
 **15 Apr 2021**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes on the `master` branch, but not yet released, will be listed here.
 ### Breaking Changes
 
 -   Renamed `didChangeLocation` to `didChangeLocationOffsetBase`.
+-   Calling super in `didChangeScale`, `didChangeLocationOffsetBase` (previously `didChangeLocation`), `didChangeContainerSize`, `didChangeViewportSize`, `didChangeContainerOffset` and `didChangeAnchor` is now discouraged.
 
 ## 0.1.0
 

--- a/src/LayoutSource.ts
+++ b/src/LayoutSource.ts
@@ -123,6 +123,8 @@ export interface LayoutSourceProps<T> {
      * values to larger or smaller than 1 to make
      * the items appear closer and further away
      * respectively.
+     *
+     * Changing the sign of a scale component is not supported.
      */
     scale?: AnimatedValueXYDerivedInput<LayoutSource>;
 

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -6,6 +6,7 @@ import {
     parseRelativeValue,
     insetSize,
     insetPoint,
+    insetTranslation,
 } from '../src/util';
 
 describe('util', () => {
@@ -210,6 +211,13 @@ describe('util', () => {
     });
 
     describe('insetSize', () => {
+        const insets = {
+            left: 1,
+            right: 2,
+            top: 3,
+            bottom: 4,
+        };
+
         it('should inset size correctly', () => {
             expect(
                 insetSize(
@@ -217,12 +225,7 @@ describe('util', () => {
                         x: 10,
                         y: 10,
                     },
-                    {
-                        left: 1,
-                        right: 2,
-                        top: 3,
-                        bottom: 4,
-                    }
+                    insets
                 )
             ).toEqual({
                 x: 7,
@@ -231,7 +234,71 @@ describe('util', () => {
         });
     });
 
+    describe('insetTranslation', () => {
+        const insets = {
+            left: 1,
+            right: 2,
+            top: 3,
+            bottom: 4,
+        };
+
+        it('should return the correct translation when not inverted', () => {
+            expect(
+                insetTranslation(insets, {
+                    anchor: { x: 0, y: 0 },
+                    invertX: false,
+                    invertY: false,
+                })
+            ).toEqual({
+                x: 1,
+                y: 3,
+            });
+
+            expect(
+                insetTranslation(insets, {
+                    anchor: { x: 1, y: 1 },
+                    invertX: false,
+                    invertY: false,
+                })
+            ).toEqual({
+                x: -2,
+                y: -4,
+            });
+        });
+
+        it('should return the correct translation when inverted', () => {
+            expect(
+                insetTranslation(insets, {
+                    anchor: { x: 0, y: 0 },
+                    invertX: true,
+                    invertY: true,
+                })
+            ).toEqual({
+                x: 2,
+                y: 4,
+            });
+
+            expect(
+                insetTranslation(insets, {
+                    anchor: { x: 1, y: 1 },
+                    invertX: true,
+                    invertY: true,
+                })
+            ).toEqual({
+                x: -1,
+                y: -3,
+            });
+        });
+    });
+
     describe('insetPoint', () => {
+        const insets = {
+            left: 1,
+            right: 2,
+            top: 3,
+            bottom: 4,
+        };
+
         it('should inset point correctly in natural direction', () => {
             expect(
                 insetPoint(
@@ -239,12 +306,7 @@ describe('util', () => {
                         x: 10,
                         y: 10,
                     },
-                    {
-                        left: 1,
-                        right: 2,
-                        top: 3,
-                        bottom: 4,
-                    }
+                    insets
                 )
             ).toEqual({
                 x: 11,
@@ -259,12 +321,7 @@ describe('util', () => {
                         x: 10,
                         y: 10,
                     },
-                    {
-                        left: 1,
-                        right: 2,
-                        top: 3,
-                        bottom: 4,
-                    },
+                    insets,
                     {
                         invertX: true,
                         invertY: true,


### PR DESCRIPTION
### Features

-   It is now possible to call `scrollTo` and `scrollBy` multiple times. Scrolling information will be merged.
-   Added previous and new values to `didChangeLocationOffsetBase` (previously `didChangeLocation`) and `willChangeScale` callbacks.
-   Added `willChangeLocationOffsetBase` and `willChangeScale` callbacks, which fire before scrolling starts.

### Breaking Changes

-   Renamed `didChangeLocation` to `didChangeLocationOffsetBase`.
-   Calling super in `didChangeScale`, `didChangeLocationOffsetBase` (previously `didChangeLocation`), `didChangeContainerSize`, `didChangeViewportSize`, `didChangeContainerOffset` and `didChangeAnchor` is now discouraged.