### PR TITLE
Glid linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes on the `master` branch, but not yet released, will be listed here.
 
 -   `setNeedsUpdate` and `shouldUpdate` on `LayoutSource` now accepts a `IItemUpdateManyOptions` parameter. Multiple calls to `setNeedsUpdate` merges options and when `update` is called, the merged options are used.
 -   Added `linkLayout` on `EvergridLayout` to allow linking multiple grids in the x, y, ot both axes. This allows both grids to share target scroll information.
+-   Added `setNeedsUpdate` to `DataSource`.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ Changes on the `master` branch, but not yet released, will be listed here.
 ### Features
 
 -   `setNeedsUpdate` and `shouldUpdate` on `LayoutSource` now accepts a `IItemUpdateManyOptions` parameter. Multiple calls to `setNeedsUpdate` merges options and when `update` is called, the merged options are used.
--   Added `linkLayout` on `EvergridLayout` to allow linking multiple grids in the x, y, ot both axes. This allows both grids to share target scroll information. A `linkedLayouts` configuration property was also added to automatically link required animated values along an axis.
--   Added `setNeedsUpdate` to `DataSource`.
--   `EvergridLayout#locationOffsetBase$` is now a public property.
+-   [[#27](https://github.com/diatche/evergrid/pull/27)] Added `linkLayout` on `EvergridLayout` to allow linking multiple grids in the x, y, ot both axes. This allows both grids to share target scroll information. A `linkedLayouts` configuration property was also added to automatically link required animated values along an axis.
+-   [[#27](https://github.com/diatche/evergrid/pull/27)] Added `setNeedsUpdate` to `DataSource`.
+-   [[#27](https://github.com/diatche/evergrid/pull/27)] `EvergridLayout#locationOffsetBase$` is now a public property.
 
 ### Bug Fixes
 
@@ -17,7 +17,7 @@ Changes on the `master` branch, but not yet released, will be listed here.
 
 ### Breaking Changes
 
--   Removed `locationOffsetTarget$` and `scaleTarget$` animated properties from `EvergridLayout`. Use `willChangeLocationOffsetBase` and `willChangeScale` callbacks respectively.
+-   [[#27](https://github.com/diatche/evergrid/pull/27)] Removed `locationOffsetTarget$` and `scaleTarget$` animated properties from `EvergridLayout`. Use `willChangeLocationOffsetBase` and `willChangeScale` callbacks respectively.
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ Changes on the `master` branch, but not yet released, will be listed here.
 ### Features
 
 -   `setNeedsUpdate` and `shouldUpdate` on `LayoutSource` now accepts a `IItemUpdateManyOptions` parameter. Multiple calls to `setNeedsUpdate` merges options and when `update` is called, the merged options are used.
+-   Added `linkLayout` on `EvergridLayout` to allow linking multiple grids in the x, y, ot both axes. This allows both grids to share target scroll information.
 
 ### Bug Fixes
 
 -   [[#26](https://github.com/diatche/evergrid/pull/26)] Fixed a bug where `scrollTo` would not work if there were certain side effects associated with desceleration.
+
+### Breaking Changes
+
+-   Removed `locationOffsetTarget$` and `scaleTarget$` animated properties from `EvergridLayout`. Use `willChangeLocationOffsetBase` and `willChangeScale` callbacks respectively.
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ Changes on the `master` branch, but not yet released, will be listed here.
 ### Features
 
 -   `setNeedsUpdate` and `shouldUpdate` on `LayoutSource` now accepts a `IItemUpdateManyOptions` parameter. Multiple calls to `setNeedsUpdate` merges options and when `update` is called, the merged options are used.
--   Added `linkLayout` on `EvergridLayout` to allow linking multiple grids in the x, y, ot both axes. This allows both grids to share target scroll information.
+-   Added `linkLayout` on `EvergridLayout` to allow linking multiple grids in the x, y, ot both axes. This allows both grids to share target scroll information. A `linkedLayouts` configuration property was also added to automatically link required animated values along an axis.
 -   Added `setNeedsUpdate` to `DataSource`.
+-   `EvergridLayout#locationOffsetBase$` is now a public property.
 
 ### Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
         "ts-jest": "^26.4.1",
         "tslib": "^2.0.2",
         "typescript": "^4.0.3"
+    },
+    "dependencies": {
+        "@ungap/weakrefs": "^0.2.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "@rollup/plugin-node-resolve": "^9.0.0",
         "@rollup/plugin-typescript": "^6.0.0",
         "@types/jest": "^26.0.14",
+        "@types/lodash.merge": "^4.6.6",
         "@types/react": "^16.9.51",
         "@types/react-native": "^0.63.25",
         "acorn": "^6.4.2",
@@ -69,6 +70,7 @@
         "typescript": "^4.0.3"
     },
     "dependencies": {
-        "@ungap/weakrefs": "^0.2.0"
+        "@ungap/weakrefs": "^0.2.0",
+        "lodash.merge": "^4.6.2"
     }
 }

--- a/src/EvergridLayout.ts
+++ b/src/EvergridLayout.ts
@@ -562,7 +562,7 @@ export default class EvergridLayout {
     }
 
     linkLayout(layout: EvergridLayout, options: { axis: LayoutLinkAxis }) {
-        if (!(layout instanceof EvergridLayout)) {
+        if (!(layout instanceof EvergridLayout) || layout === this) {
             throw new Error('Invalid EvergridLayout');
         }
         if (kLayoutLinkAxes.indexOf(options.axis) < 0) {
@@ -1583,11 +1583,6 @@ export default class EvergridLayout {
 
         this._targetDepth += 1;
 
-        // Update linked layouts
-        for (let layout of this.allLinkedLayouts()) {
-            layout._targetDepth += 1;
-        }
-
         if ('offset' in options) {
             if (typeof options.offset.x !== 'undefined') {
                 this._locationOffsetTarget.x = options.offset.x;
@@ -1622,11 +1617,6 @@ export default class EvergridLayout {
         this._transferViewOffsetToLocation();
 
         this._targetDepth -= 1;
-
-        // Update linked layouts
-        for (let layout of this.allLinkedLayouts()) {
-            layout._targetDepth -= 1;
-        }
 
         if (this._targetDepth > 0) {
             // There are multiple simulateous scroll targets

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,5 +1,5 @@
 import { PanResponderCallbacks } from 'react-native';
-import { IInsets, PanPressableCallbacks } from './types';
+import { IInsets, LayoutLinkAxis, PanPressableCallbacks } from './types';
 
 export const kInsetKeys: (keyof IInsets)[] = ['top', 'right', 'bottom', 'left'];
 export const kZeroInsets: IInsets = {
@@ -32,3 +32,5 @@ export const kPanResponderCallbackKeys: (keyof PanResponderCallbacks)[] = [
     'onPanResponderTerminationRequest',
     'onShouldBlockNativeResponder',
 ];
+
+export const kLayoutLinkAxes: readonly LayoutLinkAxis[] = ['x', 'y', 'xy'];

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,6 @@
+declare module '@ungap/weakrefs' {
+    export class WeakRef<T> {
+        constructor(value: T);
+        deref(): T;
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,4 +212,9 @@ export interface PanPressableOptions {
     longPressMaxDistance?: number;
 }
 
+export interface LayoutLinkOptions {
+    axis: LayoutLinkAxis;
+    mode?: 'auto' | 'manual';
+}
+
 export type LayoutLinkAxis = 'x' | 'y' | 'xy';

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,3 +211,5 @@ export interface PanPressableOptions {
      */
     longPressMaxDistance?: number;
 }
+
+export type LayoutLinkAxis = 'x' | 'y' | 'xy';

--- a/src/util.ts
+++ b/src/util.ts
@@ -231,24 +231,6 @@ export const parseRelativeValue = (value: string): number => {
     return parseFloat(value) * coef;
 };
 
-export function weakref<T = any>(value?: T) {
-    const _key: any = {};
-    let _map = new WeakMap<typeof _key, T>(
-        typeof value !== 'undefined' ? [_key, value] : undefined
-    );
-    return {
-        get: (): T | undefined => _map.get(_key),
-        getOrFail: (): T => {
-            let value = _map.get(_key);
-            if (typeof value === 'undefined') {
-                throw new Error('Accessing weak value which was destroyed');
-            }
-            return value;
-        },
-        set: (value: T) => _map.set(_key, value),
-    };
-}
-
 // export const estimateFinalDecayValue = (
 //     {
 //         x,

--- a/yarn.lock
+++ b/yarn.lock
@@ -723,6 +723,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@ungap/weakrefs@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@ungap/weakrefs/-/weakrefs-0.2.0.tgz#cbc3e92ca1d26579736313a210b8d7044c30f009"
+  integrity sha512-6MGYS+dIJG9yzI2j54jwkZZ5sobysMyMVbvQPfDlxBdVNI0OGgbePMNooosUnoYb9YgaJaQ52L45+0T6huIuVA==
+
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -644,6 +644,18 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/lodash.merge@^4.6.6":
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"
+  integrity sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -2677,6 +2689,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
### Features

-   Added `linkLayout` on `EvergridLayout` to allow linking multiple grids in the x, y, ot both axes. This allows both grids to share target scroll information. A `linkedLayouts` configuration property was also added to automatically link required animated values along an axis.
-   Added `setNeedsUpdate` to `DataSource`.
-   `EvergridLayout#locationOffsetBase$` is now a public property.

### Breaking Changes

-   Removed `locationOffsetTarget$` and `scaleTarget$` animated properties from `EvergridLayout`. Use `willChangeLocationOffsetBase` and `willChangeScale` callbacks respectively.